### PR TITLE
create log file along with FCTABLES to know what dates/files were correctly extracted.

### DIFF
--- a/extract_dt_plugin.toml
+++ b/extract_dt_plugin.toml
@@ -39,6 +39,7 @@
   sqlite_path = "@ARCHIVE_ROOT@/sqlite/FCTABLE/@SQLITE_MODEL_NAME@/@YYYY@/@MM@"
   sqlite_template = "FCTABLE_{PP}_{YYYY}{MM}_{HH}.sqlite"
   station_list = "@DEODE_HOME@/data/sqlite/station_list_default.csv"  
+  log_file = ""
 
 [submission.task_exceptions.RetrieveDT]
   # to find mars executable
@@ -49,10 +50,13 @@
   NODES = "#SBATCH --nodes=1"
   NTASKS = "#SBATCH --ntasks=1"
   QOS = "#SBATCH --qos=np"
-  WALLTIME = "#SBATCH --time=03:00:00"
+  WALLTIME = "#SBATCH --time=12:00:00"
 
 [submission.task_exceptions.RetrieveDT.ENV]
   MARS_READANY_BUFFER_SIZE = 17893020000
+
+[submission.task_exceptions.ExtractDT.BATCH]
+  WALLTIME = "#SBATCH --time=03:00:00"
 
 [suite_control]
   suite_definition = "DtExtractSuiteDefinition"


### PR DESCRIPTION
- Increase Walltime for both retrieval & extraction tasks
- Include the possibility to generate a logfile where the FCTABLES are created, with the list of grib files attempted to process and not found files, This allows to know what dates were successfully processed in the FCTABLES.

- The logfile is specified as "log_file" in [extractsqlite] block from the configuration file
- The plugin still works if log_file is absent or empty ("") from the config_file.